### PR TITLE
hiding and showing menu items context-dependent manner, with shinyjs …

### DIFF
--- a/app.R
+++ b/app.R
@@ -5,6 +5,7 @@ library(promises)
 plan(multisession)
 
 library(shinycssloaders)
+library(shinyjs)
 library(plotly, warn.conflicts = FALSE)
 library(reactable, warn.conflicts = FALSE)
 library(bs4Dash, warn.conflicts = FALSE)
@@ -34,6 +35,7 @@ magnetique_ui <- shinydashboard::dashboardPage(
   # body definition ---------------------------------------------------------
   body = dashboardBody(
     introjsUI(),
+    shinyjs::useShinyjs(),
     shiny::tags$script(
       HTML(
         "$(function(){
@@ -314,23 +316,27 @@ magnetique_server <- function(input, output, session) {
           ),
           selected = "DCMvsHCM"
         ),
-        selectInput("selected_ontology",
-          label = "Ontology",
-          choices = c("BP", "MF", "CC"),
-          selected = "BP"
-        ),
-        numericInput("number_genesets",
-          "Number of gene sets",
-          value = 15,
-          min = 0
-        ),
-        selectInput("color_by",
-          "Color by",
-          choices = c(
-            "z_score",
-            "gs_pvalue"
-          ),
-          selected = "z_score"
+        shinyjs::hidden(
+          tagList(
+            selectInput("selected_ontology",
+                        label = "Ontology",
+                        choices = c("BP", "MF", "CC"),
+                        selected = "BP"
+            ),
+            numericInput("number_genesets",
+                         "Number of genesets",
+                         value = 15,
+                         min = 0
+            ),
+            selectInput("color_by",
+                        "Color by",
+                        choices = c(
+                          "z_score",
+                          "gs_pvalue"
+                        ),
+                        selected = "z_score"
+            )
+          )
         ),
         actionButton("bookmarker",
           label = "Bookmark", icon = icon("heart"),
@@ -339,6 +345,19 @@ magnetique_server <- function(input, output, session) {
       )
     )
   })
+  
+  observeEvent(input$magnetique_tab, {
+    if (input$magnetique_tab == "tab-geneset-view") {
+      shinyjs::show("selected_ontology")
+      shinyjs::show("number_genesets")
+      shinyjs::show("color_by")
+    } else {
+      shinyjs::hide("selected_ontology")
+      shinyjs::hide("number_genesets")
+      shinyjs::hide("color_by")
+    }
+  })
+  
   # selector trigger data loading
   # rvalues$mygtl <- reactive({
   #   message(input$selected_contrast)


### PR DESCRIPTION
…to keep track of the selected values

This should address & (elegantly) solve the issue of keeping only relevant options displayed in the sidebar (cc @CDieterich, item 1 on the latest list)

Tested on latest dev codebase, with a fairly recent db version @tbrittoborges (locally read in replacing the call to `con <- ...`) - feel free to merge in once you verified it works on the prod instance 😉 